### PR TITLE
refactor(metadata)!: align Pinata metadata JSON with Metaplex standard

### DIFF
--- a/src/components/TokenForm.tsx
+++ b/src/components/TokenForm.tsx
@@ -114,16 +114,19 @@ export const TokenForm: React.FC<TokenFormProps> = ({
         handleLog("✅ Image uploaded successfully")
       }
 
-      // 2. Make JSON metadata
-      const metadataJson = {
-        name: formData.tokenName,
-        symbol: formData.tokenSymbol,
-        url: formData.projectWebsite,
-        description: formData.description,
-        decimals: formData.decimals,
-        supply: Number(formData.initialSupply),
-        image: finalIpfsImageUrl || "",
-      }
+      // 2. Make JSON metadata (Metaplex-compliant)
+      const metadataJson: Record<string, any> = {
+        name: formData.tokenName?.trim(),
+        symbol: formData.tokenSymbol?.trim(),
+        description: (formData.description ?? "").trim(),
+        image: finalIpfsImageUrl || undefined,
+        external_url: formData.projectWebsite?.trim() || undefined,
+      };
+
+      // Remove only undefined keys; keep description even if it's an empty string
+      Object.keys(metadataJson).forEach((k) => {
+        if (metadataJson[k] === undefined) delete (metadataJson as any)[k];
+      });
 
       // 3. Upload JSON
       if (!pinataConfig?.apiKey) {


### PR DESCRIPTION
## Summary

This PR refactors the off-chain metadata JSON (uploaded to Pinata/IPFS) to align with the Metaplex token metadata standard.

Key changes:
- Remove non-standard fields: `decimals`, `supply`
- Replace `url` with `external_url`
- Keep `description` even when blank (as an empty string "")
- Trim whitespace on user inputs (`name`, `symbol`, `description`, `external_url`) before serialization
- Prune only `undefined` keys (avoid empty strings for other fields)

Metaplex docs: https://developers.metaplex.com/token-metadata/token-standard

## Context and Motivation

Previously, the metadata JSON included fields that are not part of the official Metaplex off-chain schema (e.g., `decimals`, `supply`) and sometimes used `url` instead of `external_url`.

Clarification:
- `decimals` and `supply` are managed on-chain by the SPL Mint and therefore should not appear in the off-chain JSON.
- Other fields like `name`, `symbol`, `description`, `image`, and `external_url` are off-chain metadata fields defined by the Metaplex standard.

Aligning to the standard improves compatibility with wallets, indexers, and Solana tooling. Trimming inputs ensures no accidental leading/trailing spaces are stored in the metadata.

## Changes

- Refactored the JSON construction where metadata is built before uploading to Pinata/IPFS:
  - Use: `name`, `symbol`, `description`, `image`, `external_url`
  - Remove: `decimals`, `supply`
  - Rename: `url` ➜ `external_url`
  - Keep `description` as `""` when the user leaves it blank
  - Apply `.trim()` to `name`, `symbol`, `description`, and `external_url`
  - Omit any keys that are `undefined` (e.g., do not send `image: ""`)

### Code change (matches the actual implementation)

```ts
const metadataJson: Record<string, any> = {
  name: formData.tokenName?.trim(),
  symbol: formData.tokenSymbol?.trim(),
  description: (formData.description ?? "").trim(),
  image: finalIpfsImageUrl || undefined,
  external_url: formData.projectWebsite?.trim() || undefined,
};

// Remove only undefined keys; keep description even if it's an empty string
Object.keys(metadataJson).forEach((k) => {
  if (metadataJson[k] === undefined) delete (metadataJson as any)[k];
});
```

## Testing

I have not tested these changes locally, so could someone please run and verify the flow in the app to ensure everything still works as expected?

Suggested steps for verification:
1. Run the widget locally and go through the token creation flow.
2. Upload an image.
3. Enter a valid project website URL (e.g., `https://example.com`) and verify in the uploaded JSON (via the resulting IPFS/gateway) that `external_url` is present
4. Leave the description blank and confirm it appears as an empty string `""` in the uploaded JSON.
5. Confirm the JSON does not include `decimals`, `supply`, or `url`.
6. Validate that wallets/indexers ingest the metadata correctly.
7. Manually test inputs with leading/trailing spaces and confirm they are trimmed in the resulting JSON.